### PR TITLE
feat/add-react-router

### DIFF
--- a/v56-team22-surgery-status-board/package-lock.json
+++ b/v56-team22-surgery-status-board/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router": "^7.7.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -5223,6 +5224,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.44.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
@@ -8200,6 +8209,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-test-renderer": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
@@ -8457,6 +8487,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/v56-team22-surgery-status-board/package.json
+++ b/v56-team22-surgery-status-board/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router": "^7.7.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/v56-team22-surgery-status-board/src/App.tsx
+++ b/v56-team22-surgery-status-board/src/App.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
+import { Button } from './components/ui/button';
+import { Link } from 'react-router';
 
 function App() {
   const [count, setCount] = useState(0);
@@ -28,6 +30,9 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <Link to="/sign-in">
+        <Button>Sign in</Button>
+      </Link>
     </>
   );
 }

--- a/v56-team22-surgery-status-board/src/main.tsx
+++ b/v56-team22-surgery-status-board/src/main.tsx
@@ -2,9 +2,22 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { RouterProvider, createBrowserRouter } from 'react-router';
+import SignIn from './screens/SignIn.tsx';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    Component: App,
+  },
+  {
+    path: '/sign-in',
+    Component: SignIn,
+  },
+]);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>
 );

--- a/v56-team22-surgery-status-board/src/screens/SignIn.tsx
+++ b/v56-team22-surgery-status-board/src/screens/SignIn.tsx
@@ -1,0 +1,3 @@
+const SignIn = () => <h1>Sign in</h1>;
+
+export default SignIn;


### PR DESCRIPTION
### Description
We don't currently have any capability for routing in the app, so this PR adds the React Router DOM library for that.

I've set up 'data' mode for the router - read more about it here if you'd like: https://reactrouter.com/start/modes

I've also added a button to the home screen to link to a new sign in screen in order to test out the routing and ensure that it works (and also tested a shadcn button lol).
