### PR TITLE
refactor(Footer): make the footer mobile responsive

### DIFF
--- a/v56-team22-surgery-status-board/src/components/Footer/Footer.tsx
+++ b/v56-team22-surgery-status-board/src/components/Footer/Footer.tsx
@@ -19,8 +19,7 @@ const devNames = [
     github: 'https://github.com/rachel-labri-tipton',
     linkedin: 'https://www.linkedin.com/in/rachel-labri-tipton',
   },
-  { name: 'Rapha', 
-  github: 'https://github.com/Excalibur097'},
+  { name: 'Rapha', github: 'https://github.com/Excalibur097' },
 ];
 
 const pages = [
@@ -30,13 +29,21 @@ const pages = [
 
 const Footer = () => {
   return (
-    <footer className="w-full px-6 py-8 bg-[#16a34a] flex flex-col justify-between items-center text-gray-800">
+    <footer className="w-full px-4 py-8 bg-primary text-gray-800">
       <div className="flex flex-col md:flex-row justify-between items-start w-full max-w-6xl mx-auto gap-8">
-        <FooterLogo />
-        <DeveloperItems devs={devNames} />
-        <PageList pages={pages} />
+        <div className="w-full md:w-1/3 flex justify-center md:justify-start">
+          <FooterLogo />
+        </div>
+        <div className="w-full md:w-1/3 flex justify-center">
+          <DeveloperItems devs={devNames} />
+        </div>
+        <div className="w-full md:w-1/3 flex justify-center md:justify-end">
+          <PageList pages={pages} />
+        </div>
       </div>
-      <GithubProjectLink />
+      <div className="mt-6 w-full flex justify-center">
+        <GithubProjectLink />
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
PR address #63 

Small changes in the styling to make the footer fully responsive on mobile devices.The layout now adjusts properly on small screens

Breakpoint = 768px
<img width="735" height="655" alt="image" src="https://github.com/user-attachments/assets/6376a150-d8b7-4403-a5fd-2e5319936b98" />
