### PR TITLE
76 add routes to router and generic components for views

### DIFF
--- a/v56-team22-surgery-status-board/src/main.tsx
+++ b/v56-team22-surgery-status-board/src/main.tsx
@@ -5,6 +5,8 @@ import App from './App.tsx';
 import { RouterProvider, createBrowserRouter } from 'react-router';
 import SignIn from './screens/SignIn.tsx';
 import PatientStatusBoard from './screens/PatientStatusBoard.tsx';
+import PatientInformation from './screens/PatientInformation.tsx';
+import PatientStatusUpdate from './screens/PatientStatusUpdate.tsx';
 
 const router = createBrowserRouter([
   {
@@ -18,8 +20,15 @@ const router = createBrowserRouter([
   {
     path: '/patient-status-board',
     Component: PatientStatusBoard,
-  }
-
+  },
+  {
+    path: '/patient-information',
+    Component: PatientInformation,
+  },
+  {
+    path: '/patient-status-update',
+    Component: PatientStatusUpdate,
+  },
 ]);
 
 createRoot(document.getElementById('root')!).render(

--- a/v56-team22-surgery-status-board/src/main.tsx
+++ b/v56-team22-surgery-status-board/src/main.tsx
@@ -18,7 +18,7 @@ const router = createBrowserRouter([
     Component: SignIn,
   },
   {
-    path: '/patient-status-board',
+    path: '/patient-status',
     Component: PatientStatusBoard,
   },
   {
@@ -26,7 +26,7 @@ const router = createBrowserRouter([
     Component: PatientInformation,
   },
   {
-    path: '/patient-status-update',
+    path: '/update-patient',
     Component: PatientStatusUpdate,
   },
 ]);

--- a/v56-team22-surgery-status-board/src/screens/Home.tsx
+++ b/v56-team22-surgery-status-board/src/screens/Home.tsx
@@ -4,32 +4,40 @@ import { Button } from "@/components/ui/button";
 
 const Home = () => {
   return (
-    <div className='px-[30px] md:px-[100px] mt-[100px] flex flex-col justify-center items-center'>
-      <h1 className='text-4xl font-bold text-center mb-[60px]'>Welcome to Appname</h1>
-      <p className='text-lg text-center mb-[30px]'>
-        Monitor your loved ones' surgery journey with ease.
-        Appname provides real-time updates on patient status—Checked In,
-        Pre-Procedure, In Progress, Closing, Recovery, Complete and Dismissal <br />
+    <div className="px-[30px] md:px-[100px] mt-[100px] flex flex-col justify-center items-center">
+      <h1 className="text-4xl font-bold text-center mb-[60px]">
+        Welcome to Appname
+      </h1>
+      <p className="text-lg text-center mb-[30px]">
+        Monitor your loved ones' surgery journey with ease. Appname provides
+        real-time updates on patient status—Checked In, Pre-Procedure, In
+        Progress, Closing, Recovery, Complete and Dismissal <br />
       </p>
-      <p className='text-lg text-center mb-[100px]'> 
-        You stay informed every step of the way.
-        Simple, secure, and compassionate care at your fingertips.
+      <p className="text-lg text-center mb-[100px]">
+        You stay informed every step of the way. Simple, secure, and
+        compassionate care at your fingertips.
       </p>
 
-      <div className='flex flex-col gap-[30px] justify-center md:flex-row md:gap-[100px] mb-[100px]'>
+      <div className="flex flex-col gap-[30px] justify-center md:flex-row md:gap-[100px] mb-[100px]">
         <Link to={'/sign-in'}>
-          <Button  variant="default"className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white">
+          <Button
+            variant="default"
+            className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white"
+          >
             Sign in
           </Button>
         </Link>
-        <Link to={'/patient-status-board'}>
-          <Button  variant="default"className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white">
+        <Link to={'/patient-status'}>
+          <Button
+            variant="default"
+            className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white"
+          >
             Sign in as guest
           </Button>
         </Link>
       </div>
     </div>
-  )
+  );
 }
 
 export default Home

--- a/v56-team22-surgery-status-board/src/screens/PatientInformation.tsx
+++ b/v56-team22-surgery-status-board/src/screens/PatientInformation.tsx
@@ -1,0 +1,3 @@
+const PatientInformation = () => <h1>Admins will view and update patient information here.</h1>;
+
+export default PatientInformation;

--- a/v56-team22-surgery-status-board/src/screens/PatientStatusUpdate.tsx
+++ b/v56-team22-surgery-status-board/src/screens/PatientStatusUpdate.tsx
@@ -1,0 +1,3 @@
+const PatientStatusUpdate = () => <h1>Admins and Surgical staff will update patient status here.</h1>;
+
+export default PatientStatusUpdate;


### PR DESCRIPTION
This PR addresses issue #76 and does the following: 

- Adds or updates routes to the router for `/patient-status`, `/patient-information`, and `/update-patient`
- Adds generic views with a simple `h1` tag for `patient information` screen and `update patient status screen`
- Updates the link from the homepage for guest sign-in to route to `patient-status`

Would be good to know if these routes are clear. I could see `update-patient` being a bit confusing. It's intended for updating patient status. 