### PR TITLE
75 wrap router in main layout component

### DIFF
--- a/v56-team22-surgery-status-board/src/App.tsx
+++ b/v56-team22-surgery-status-board/src/App.tsx
@@ -1,11 +1,8 @@
-import MainLayout from './layout/MainLayout';
 import  Home  from './screens/Home';
 
 function App() {
   return (
-      <MainLayout>
         <Home/>
-      </MainLayout>
   );
 }
 

--- a/v56-team22-surgery-status-board/src/layout/MainLayoutWrapper.tsx
+++ b/v56-team22-surgery-status-board/src/layout/MainLayoutWrapper.tsx
@@ -1,0 +1,10 @@
+import MainLayout from './MainLayout';
+import { Outlet } from 'react-router';
+
+const MainLayoutWrapper = () => (
+  <MainLayout>
+    <Outlet />
+  </MainLayout>
+);
+
+export default MainLayoutWrapper;

--- a/v56-team22-surgery-status-board/src/main.tsx
+++ b/v56-team22-surgery-status-board/src/main.tsx
@@ -1,49 +1,17 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { RouterProvider, createBrowserRouter} from 'react-router';
+import { AuthProvider } from './contexts/AuthContext';
+import routes from './routes.ts';
 import './index.css';
-import App from './App.tsx';
-import { RouterProvider, createBrowserRouter, Outlet } from 'react-router';
-import SignIn from './screens/SignIn.tsx';
-import PatientStatusBoard from './screens/PatientStatusBoard.tsx';
-import PatientInformation from './screens/PatientInformation.tsx';
-import PatientStatusUpdate from './screens/PatientStatusUpdate.tsx';
-import MainLayout from './layout/MainLayout.tsx';
 
 
-export const MainLayoutWrapper = () => (
-  <MainLayout>
-    <Outlet />
-  </MainLayout>
-);
-
-
-const router = createBrowserRouter([
-  {
-    path: '/', Component: MainLayoutWrapper,
-    children: [
-      { index: true, Component: App },
-      {
-        path: '/sign-in',
-        Component: SignIn,
-      },
-      {
-        path: '/patient-status',
-        Component: PatientStatusBoard,
-      },
-      {
-        path: '/patient-information',
-        Component: PatientInformation,
-      },
-      {
-        path: '/update-patient',
-        Component: PatientStatusUpdate,
-      },
-    ],
-    }
-]);
+const router = createBrowserRouter(routes)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>
 );

--- a/v56-team22-surgery-status-board/src/main.tsx
+++ b/v56-team22-surgery-status-board/src/main.tsx
@@ -2,33 +2,44 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
-import { RouterProvider, createBrowserRouter } from 'react-router';
+import { RouterProvider, createBrowserRouter, Outlet } from 'react-router';
 import SignIn from './screens/SignIn.tsx';
 import PatientStatusBoard from './screens/PatientStatusBoard.tsx';
 import PatientInformation from './screens/PatientInformation.tsx';
 import PatientStatusUpdate from './screens/PatientStatusUpdate.tsx';
+import MainLayout from './layout/MainLayout.tsx';
+
+
+export const MainLayoutWrapper = () => (
+  <MainLayout>
+    <Outlet />
+  </MainLayout>
+);
+
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    Component: App,
-  },
-  {
-    path: '/sign-in',
-    Component: SignIn,
-  },
-  {
-    path: '/patient-status',
-    Component: PatientStatusBoard,
-  },
-  {
-    path: '/patient-information',
-    Component: PatientInformation,
-  },
-  {
-    path: '/update-patient',
-    Component: PatientStatusUpdate,
-  },
+    path: '/', Component: MainLayoutWrapper,
+    children: [
+      { index: true, Component: App },
+      {
+        path: '/sign-in',
+        Component: SignIn,
+      },
+      {
+        path: '/patient-status',
+        Component: PatientStatusBoard,
+      },
+      {
+        path: '/patient-information',
+        Component: PatientInformation,
+      },
+      {
+        path: '/update-patient',
+        Component: PatientStatusUpdate,
+      },
+    ],
+    }
 ]);
 
 createRoot(document.getElementById('root')!).render(

--- a/v56-team22-surgery-status-board/src/routes.ts
+++ b/v56-team22-surgery-status-board/src/routes.ts
@@ -1,0 +1,22 @@
+import App from './App.tsx';
+import SignIn from './components/SignIn/index.tsx';
+import PatientStatusBoard from './screens/PatientStatusBoard.tsx';
+import PatientInformation from './screens/PatientInformation.tsx';
+import PatientStatusUpdate from './screens/PatientStatusUpdate.tsx';
+import MainLayoutWrapper from './layout/MainLayoutWrapper.tsx';
+
+const routes = [
+  {
+    path: '/',
+    Component: MainLayoutWrapper,
+    children: [
+      { index: true, Component: App },
+      { path: '/sign-in', Component: SignIn },
+      { path: '/patient-status', Component: PatientStatusBoard },
+      { path: '/patient-information', Component: PatientInformation },
+      { path: '/update-patient', Component: PatientStatusUpdate },
+    ],
+  },
+];
+
+export default routes;


### PR DESCRIPTION
This PR address #75 

- adds a `MainLayoutWrapper` to the `main.tsx` file and wraps the routes in the router with the component so each page will have a header and a footer. 
- removes `MainLayout` component from the `App.tsx` file so the header and footer doesn't appear twice
