### PR TITLE
feat: implement auto pagination mode with toggle functionality

### DIFF
--- a/v56-team22-surgery-status-board/src/components/PatientStatusTable/PaginationController.tsx
+++ b/v56-team22-surgery-status-board/src/components/PatientStatusTable/PaginationController.tsx
@@ -34,6 +34,8 @@ function PaginationController<TData>({
   const [paginationMode, setPaginationMode] =
     useState<PaginationMode>('manual');
 
+  const [countdown, setCountdown] = useState(20);
+
   const totalPages = table.getPageCount();
   const currentPage = table.getState().pagination.pageIndex;
   const totalItems = table.getFilteredRowModel().rows.length;
@@ -48,19 +50,29 @@ function PaginationController<TData>({
 
   // auto pagination every 15 seconds
   useEffect(() => {
+    if (paginationMode !== 'auto') {
+      setCountdown(20);
+      return;
+    }
+    setCountdown(20);
     if (paginationMode !== 'auto') return;
-
     const interval = setInterval(() => {
-      const currentPageIndex = table.getState().pagination.pageIndex;
-      const pageCount = table.getPageCount();
-      if (pageCount > 0) {
-        if (currentPageIndex < pageCount - 1) {
-          table.nextPage();
-        } else {
-          table.setPageIndex(0);
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          const currentPageIndex = table.getState().pagination.pageIndex;
+          const pageCount = table.getPageCount();
+          if (pageCount > 0) {
+            if (currentPageIndex < pageCount - 1) {
+              table.nextPage();
+            } else {
+              table.setPageIndex(0);
+            }
+          }
+          return 20;
         }
-      }
-    }, 15000);
+        return prev - 1;
+      });
+    }, 1000);
     return () => clearInterval(interval);
   }, [paginationMode, table]);
 
@@ -165,6 +177,11 @@ function PaginationController<TData>({
           {paginationMode === 'auto' && <FaPause className="text-yellow-600" />}
           {paginationMode === 'paused' && <FaStop className="text-red-600" />}
         </Button>
+        {paginationMode === 'auto' && (
+          <span className="text-xs text-gray-500">
+            Next page in {countdown}s
+          </span>
+        )}
       </div>
     </div>
   );

--- a/v56-team22-surgery-status-board/src/components/PatientStatusTable/PaginationController.tsx
+++ b/v56-team22-surgery-status-board/src/components/PatientStatusTable/PaginationController.tsx
@@ -17,10 +17,9 @@ import {
   FaAngleRight,
   FaPause,
   FaPlay,
-  FaStop,
 } from 'react-icons/fa';
 
-type PaginationMode = 'manual' | 'auto' | 'paused';
+type PaginationMode = 'manual' | 'auto';
 interface PaginationControllerProps<TData> {
   table: ReactTable<TData>;
 }
@@ -80,11 +79,12 @@ function PaginationController<TData>({
   const isPreviousDisabled = currentPage === 0;
   const isNextDisabled = currentPage === totalPages - 1;
 
+  // controller between manual and auto pagination
+  const isControllerDisabled = paginationMode === 'auto';
+
   const togglePaginationMode = () => {
     if (paginationMode === 'manual') {
       setPaginationMode('auto');
-    } else if (paginationMode === 'auto') {
-      setPaginationMode('paused');
     } else {
       setPaginationMode('manual');
     }
@@ -101,6 +101,7 @@ function PaginationController<TData>({
         <Select
           value={pageSize.toString()}
           onValueChange={handlePageSizeChange}
+          disabled={isControllerDisabled}
         >
           <SelectTrigger className="w-24">
             <SelectValue placeholder="Rows per page" />
@@ -121,7 +122,7 @@ function PaginationController<TData>({
             onClick={() => table.setPageIndex(0)}
             size="sm"
             variant="outline"
-            disabled={currentPage === 0}
+            disabled={isControllerDisabled || currentPage === 0}
             className="transition-colors duration-200"
             aria-label="Go to first page"
           >
@@ -129,11 +130,15 @@ function PaginationController<TData>({
           </Button>
           <div
             className={
-              isPreviousDisabled
+              isControllerDisabled || isPreviousDisabled
                 ? 'pointer-events-none opacity-50'
                 : 'cursor-pointer'
             }
-            onClick={() => !isPreviousDisabled && table.previousPage()}
+            onClick={() =>
+              !isControllerDisabled &&
+              !isPreviousDisabled &&
+              table.previousPage()
+            }
             aria-disabled={isPreviousDisabled}
             aria-label="Go to previous page"
           >
@@ -143,11 +148,13 @@ function PaginationController<TData>({
           </div>
           <div
             className={
-              isNextDisabled
+              isControllerDisabled || isNextDisabled
                 ? 'pointer-events-none opacity-50'
                 : 'cursor-pointer'
             }
-            onClick={() => !isNextDisabled && table.nextPage()}
+            onClick={() =>
+              !isControllerDisabled && !isNextDisabled && table.nextPage()
+            }
             aria-disabled={isNextDisabled}
             aria-label="Go to next page"
           >
@@ -159,7 +166,7 @@ function PaginationController<TData>({
             onClick={() => table.setPageIndex(totalPages - 1)}
             size="sm"
             variant="outline"
-            disabled={currentPage === totalPages - 1}
+            disabled={isControllerDisabled || currentPage === totalPages - 1}
             className="transition-colors duration-200"
             aria-label="Go to last page"
           >
@@ -175,7 +182,6 @@ function PaginationController<TData>({
         >
           {paginationMode === 'manual' && <FaPlay className="text-green-600" />}
           {paginationMode === 'auto' && <FaPause className="text-yellow-600" />}
-          {paginationMode === 'paused' && <FaStop className="text-red-600" />}
         </Button>
         {paginationMode === 'auto' && (
           <span className="text-xs text-gray-500">


### PR DESCRIPTION
PR address #71 

* Added paginationMode state (manual, auto, paused)
* Updated mode toggle button to switch between modes with visual icons
* Added useEffect that triggers page changes every 20 seconds in auto mode


<img width="34" height="30" alt="image" src="https://github.com/user-attachments/assets/5eddb292-a169-452a-8e76-28a87f9ab8c9" />
<img width="35" height="30" alt="image" src="https://github.com/user-attachments/assets/76db2cb9-0486-47d2-b6a9-44e9c2a6189c" />
<img width="35" height="30" alt="image" src="https://github.com/user-attachments/assets/0876d1d8-24b0-4c18-b639-1198f37b52c4" />
 
The icons of the toggles (manual, auto, paused)

* <img width="641" height="99" alt="image" src="https://github.com/user-attachments/assets/470d3f35-fff1-4148-b5f6-8b76fd0edf08" />


I've also added a countdown for the UX  
