### PR TITLE
fix: remove dismissed patients from the PatientStatusTable

### DIFF
--- a/v56-team22-surgery-status-board/src/components/PatientStatusTable/PatientStatusTable.tsx
+++ b/v56-team22-surgery-status-board/src/components/PatientStatusTable/PatientStatusTable.tsx
@@ -7,7 +7,8 @@ import type { TableRole } from "@/constant/patient-table";
 const PatientStatusTable = () => {
   const [userRole, setUserRole] = useState<TableRole>("guest"); // default to guest
   const columns = getColumns(userRole);
-
+  // Filter out dismissed patients
+const filteredPatientData = patientData.filter(patient => patient.status !== 'Dismissal');
 
   return (
 
@@ -34,7 +35,7 @@ const PatientStatusTable = () => {
         </button>
       </div>
    
-        <DataTable columns={columns} data={patientData} role={userRole}/>
+        <DataTable columns={columns} data={filteredPatientData} role={userRole}/>
  
     </div>
   );


### PR DESCRIPTION
This PR addresses issue #100 :
The project spec indicates that  _Patients are added to the screen when the addition of their patient information is complete (i.e. Checked In) and removed when their status changes to Dismissed._

I've added a line of code to the `PatientStatusBoard` that does the following:

- Filters patient data for patients with a `dismissed` status and removes them from the patient status board. The `datatable` now loads `filteredPatientData`



